### PR TITLE
Update Star Wars (2017) settings

### DIFF
--- a/machines/StarWars_cs_19_G5vLR.md
+++ b/machines/StarWars_cs_19_G5vLR.md
@@ -17,12 +17,10 @@ This is the Stern 2017 version.
 - #48 Ball Save Time: 3
 - #49 Timed Plunger OFF
 - #50 Flipper Ball Launch OFF
-- #51 Coin Door Ball Saver: YES
 - #52 Competition Mode: YES
 - #53 Consolation Ball: NO
 - #57 Player Competition: NO
 - #63 Lost Ball Recovery: NO
-- #64 Coin Door Disable Tilt: YES
 
 #### Feature Adjustments
 


### PR DESCRIPTION
Removed coin door ball saver and coin door disable tilt from recommended settings as the game doesn't have a door switch